### PR TITLE
docs: CLAUDE.md を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+PPTX ファイルを SVG プレビューに変換する MCP (Model Context Protocol) サーバー。stdio トランスポートで通信し、`preview_pptx` ツールを提供する。
+
+## コマンド
+
+- `npm run build` — TypeScript コンパイル (`tsc`)
+- `npm start` — サーバー起動 (`node dist/index.js`)
+- `npm run lint` — ESLint 実行
+- `npm run typecheck` — 型チェック (`tsc --noEmit`)
+
+テストフレームワークは未導入。品質チェックは `npm run lint` と `npm run typecheck` で行う。
+
+## アーキテクチャ
+
+```
+src/
+├── index.ts              # エントリーポイント: McpServer 生成 + stdio トランスポート接続
+└── tools/
+    └── previewPptx.ts    # preview_pptx ツール: PPTX → SVG 変換
+```
+
+- `src/index.ts` で `McpServer` を生成し、各ツール登録関数を呼び出す構成
+- ツールは `src/tools/` 配下に `register*Tool(server: McpServer)` 関数として実装し、`index.ts` から登録する
+- PPTX → SVG 変換には `pptx-glimpse` ライブラリを使用
+- 入力バリデーションには `zod` を使用（MCP SDK のツール定義と統合）


### PR DESCRIPTION
## 概要

- Claude Code がリポジトリで作業する際のガイダンスファイル（CLAUDE.md）を追加
- プロジェクト概要、開発コマンド、アーキテクチャを記載

## テスト計画

- [x] `npm run lint` パス確認
- [x] `npm run typecheck` パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)